### PR TITLE
Add liquidity buying fyDai in the pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ethereumjs-util": "^7.0.3",
     "ethers": "^5.0.7",
     "ganache-time-traveler": "^1.0.14",
+    "mathjs": "^7.3.0",
     "mocha": "^7.1.0",
     "prettier": "^2.0.5",
     "solhint": "^3.2.0",

--- a/test/531_poolProxy_base.ts
+++ b/test/531_poolProxy_base.ts
@@ -119,7 +119,7 @@ contract('PoolProxy', async (accounts) => {
       await dai.approve(pool0.address, MAX, { from: user })
       await fyDai0.approve(pool0.address, MAX, { from: user })
       await controller.addDelegate(proxy.address, { from: user })
-      await pool0.addDelegate(proxy.address, { from: user }) 
+      await pool0.addDelegate(proxy.address, { from: user })
     }
 
     // Initialize pools
@@ -221,12 +221,18 @@ contract('PoolProxy', async (accounts) => {
     const fyDaiVirtualReserves = bnify((await pool0.getFYDaiReserves()).toString())
     const maxDaiUsed = bnify(oneToken)
 
-
     await dai.mint(user2, maxDaiUsed, { from: owner })
     const daiBalanceBefore = await dai.balanceOf(user2)
 
-    const timeToMaturity = (await fyDai0.maturity()).toNumber() - (await web3.eth.getBlock(await web3.eth.getBlockNumber())).timestamp
-    const fyDaiIn = (fyDaiForMint(daiReserves.toString(), fyDaiRealReserves.toString(), fyDaiVirtualReserves.toString(), maxDaiUsed.toString(), timeToMaturity.toString())).toString()
+    const timeToMaturity =
+      (await fyDai0.maturity()).toNumber() - (await web3.eth.getBlock(await web3.eth.getBlockNumber())).timestamp
+    const fyDaiIn = fyDaiForMint(
+      daiReserves.toString(),
+      fyDaiRealReserves.toString(),
+      fyDaiVirtualReserves.toString(),
+      maxDaiUsed.toString(),
+      timeToMaturity.toString()
+    ).toString()
     await proxy.buyAddLiquidityWithSignature(pool0.address, fyDaiIn, maxDaiUsed, '0x', '0x', '0x', { from: user2 })
 
     const daiLeft = await dai.balanceOf(user2)

--- a/test/532_poolProxy_signatures.ts
+++ b/test/532_poolProxy_signatures.ts
@@ -142,27 +142,27 @@ contract('PoolProxy - Signatures', async (accounts) => {
 
     it('checks missing approvals and signatures for adding liquidity', async () => {
       let result = await proxy.addLiquidityCheck(pool0.address, { from: user3 })
-  
+
       assert.equal(result[0], false)
       assert.equal(result[1], false)
       assert.equal(result[2], false)
-  
+
       await dai.approve(proxy.address, MAX, { from: user3 })
       result = await proxy.addLiquidityCheck(pool0.address, { from: user3 })
       assert.equal(result[0], false)
       assert.equal(result[1], true)
       assert.equal(result[2], false)
-  
+
       await controller.addDelegate(proxy.address, { from: user3 })
       result = await proxy.addLiquidityCheck(pool0.address, { from: user3 })
       assert.equal(result[0], false)
       assert.equal(result[1], true)
       assert.equal(result[2], true)
-  
+
       const oneToken = toWad(1)
       await dai.mint(user3, bnify(toWad(2)), { from: owner })
       await proxy.addLiquidityWithSignature(pool0.address, oneToken, MAX, '0x', '0x', { from: user3 })
-  
+
       result = await proxy.addLiquidityCheck(pool0.address, { from: user3 })
       assert.equal(result[0], true)
       assert.equal(result[1], true)
@@ -238,22 +238,22 @@ contract('PoolProxy - Signatures', async (accounts) => {
         assert.equal(result[0], true)
         assert.equal(result[1], false)
         assert.equal(result[2], false)
-  
+
         await controller.addDelegate(proxy.address, { from: user3 })
         result = await proxy.removeLiquidityEarlyDaiPoolCheck(pool0.address, { from: user3 })
         assert.equal(result[0], true)
         assert.equal(result[1], true)
         assert.equal(result[2], false)
-  
+
         await pool0.addDelegate(proxy.address, { from: user3 })
         result = await proxy.removeLiquidityEarlyDaiPoolCheck(pool0.address, { from: user3 })
         assert.equal(result[0], true)
         assert.equal(result[1], true)
         assert.equal(result[2], true)
-  
+
         await proxy.removeLiquidityEarlyDaiPool(pool0.address, await pool0.balanceOf(user3), 0, 0, { from: user3 }) // Check it doesn't revert.
       })
-  
+
       it('removes liquidity early by selling with only the pool signature', async () => {
         const poolTokens = await pool0.balanceOf(user2)
 
@@ -290,25 +290,32 @@ contract('PoolProxy - Signatures', async (accounts) => {
       it('checks missing approvals and signatures for removing liquidity by repaying', async () => {
         await pool0.transfer(user3, await pool0.balanceOf(user3))
 
-        let result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user3 })  
+        let result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user3 })
         assert.equal(result[0], false)
         assert.equal(result[1], false)
         assert.equal(result[2], false)
-  
+
         await controller.addDelegate(proxy.address, { from: user3 })
         result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user3 })
         assert.equal(result[0], false)
         assert.equal(result[1], true)
         assert.equal(result[2], false)
-  
+
         await pool0.addDelegate(proxy.address, { from: user3 })
         result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user3 })
         assert.equal(result[0], false)
         assert.equal(result[1], true)
         assert.equal(result[2], true)
-  
+
         const poolTokens = await pool0.balanceOf(user3)
-        await proxy.removeLiquidityEarlyDaiFixedWithSignature(pool0.address, poolTokens.div(bnify(2)), '0', '0x', '0x', { from: user3 })
+        await proxy.removeLiquidityEarlyDaiFixedWithSignature(
+          pool0.address,
+          poolTokens.div(bnify(2)),
+          '0',
+          '0x',
+          '0x',
+          { from: user3 }
+        )
         result = await proxy.removeLiquidityEarlyDaiFixedCheck(pool0.address, { from: user3 })
         assert.equal(result[0], true)
         assert.equal(result[1], true)
@@ -316,7 +323,7 @@ contract('PoolProxy - Signatures', async (accounts) => {
 
         await proxy.removeLiquidityEarlyDaiFixed(pool0.address, poolTokens.div(bnify(2)), '0', { from: user3 })
       })
-  
+
       it('removes liquidity early by repaying', async () => {
         const poolTokens = await pool0.balanceOf(user2)
 
@@ -330,29 +337,31 @@ contract('PoolProxy - Signatures', async (accounts) => {
         await helper.advanceTime(31556952)
         await helper.advanceBlock()
         await fyDai0.mature()
-  
+
         await pool0.transfer(user3, await pool0.balanceOf(user3))
         let result = await proxy.removeLiquidityMatureCheck(pool0.address, { from: user3 })
-  
+
         assert.equal(result[0], false)
         assert.equal(result[1], false)
         assert.equal(result[2], false)
-  
+
         await controller.addDelegate(proxy.address, { from: user3 })
         result = await proxy.removeLiquidityMatureCheck(pool0.address, { from: user3 })
         assert.equal(result[0], false)
         assert.equal(result[1], true)
         assert.equal(result[2], false)
-  
+
         await pool0.addDelegate(proxy.address, { from: user3 })
         result = await proxy.removeLiquidityMatureCheck(pool0.address, { from: user3 })
         assert.equal(result[0], false)
         assert.equal(result[1], true)
         assert.equal(result[2], true)
-  
+
         const poolTokens = await pool0.balanceOf(user3)
-        await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens.div(bnify(2)), '0x', '0x', { from: user3 })
-  
+        await proxy.removeLiquidityMatureWithSignature(pool0.address, poolTokens.div(bnify(2)), '0x', '0x', {
+          from: user3,
+        })
+
         result = await proxy.removeLiquidityMatureCheck(pool0.address, { from: user3 })
         assert.equal(result[0], true)
         assert.equal(result[1], true)

--- a/test/541_importProxy.ts
+++ b/test/541_importProxy.ts
@@ -128,7 +128,9 @@ contract('ImportProxy', async (accounts) => {
     const wethCollateral = bnify((await vat.urns(WETH, importProxy.address)).ink).toString()
 
     await expectRevert(
-      importProxy.importFromProxy(pool1.address, user, wethCollateral, bnify(daiDebt).mul(10), toRay(2), { from: user }),
+      importProxy.importFromProxy(pool1.address, user, wethCollateral, bnify(daiDebt).mul(10), toRay(2), {
+        from: user,
+      }),
       'ImportProxy: Not enough debt in Maker'
     )
   })
@@ -149,7 +151,9 @@ contract('ImportProxy', async (accounts) => {
     const wethCollateral = bnify((await vat.urns(WETH, importProxy.address)).ink).toString()
 
     await expectRevert(
-      importProxy.importFromProxy(pool1.address, user, bnify(wethCollateral).mul(10), daiDebt, toRay(2), { from: user }),
+      importProxy.importFromProxy(pool1.address, user, bnify(wethCollateral).mul(10), daiDebt, toRay(2), {
+        from: user,
+      }),
       'ImportProxy: Not enough collateral in Maker'
     )
   })

--- a/test/551_exportProxy.ts
+++ b/test/551_exportProxy.ts
@@ -148,6 +148,8 @@ contract('ExportProxy', async (accounts) => {
     const controllerSig = sign(controllerDigest, userPrivateKey)
     await vat.hope(exportProxy.address, { from: user }) // Allowing ExportProxy to manipulate debt for user in MakerDAO
 
-    await exportProxy.exportPositionWithSignature(pool1.address, wethTokens1, toBorrow, toRay(1), controllerSig, { from: user })
+    await exportProxy.exportPositionWithSignature(pool1.address, wethTokens1, toBorrow, toRay(1), controllerSig, {
+      from: user,
+    })
   })
 })

--- a/test/552_exportCdpProxy.ts
+++ b/test/552_exportCdpProxy.ts
@@ -48,12 +48,7 @@ contract('ExportCdpProxy', async (accounts) => {
     pool1 = await Pool.new(dai.address, fyDai1.address, 'Name', 'Symbol', { from: owner })
 
     // Setup ExportCdpProxy
-    exportCdpProxy = await ExportCdpProxy.new(
-      controller.address,
-      [pool1.address],
-      cdpMgr.address,
-      { from: owner }
-    )
+    exportCdpProxy = await ExportCdpProxy.new(controller.address, [pool1.address], cdpMgr.address, { from: owner })
 
     // Allow owner to mint fyDai the sneaky way, without recording a debt in controller
     await fyDai1.orchestrate(owner, id('mint(address,uint256)'), { from: owner })
@@ -78,7 +73,7 @@ contract('ExportCdpProxy', async (accounts) => {
     urn = await cdpMgr.urns(cdp, { from: user })
 
     // Allow ExportCdpProxy to manipulate the cdp in MakerDAO
-    await cdpMgr.cdpAllow(cdp, exportCdpProxy.address, 1, { from: user }) 
+    await cdpMgr.cdpAllow(cdp, exportCdpProxy.address, 1, { from: user })
   })
 
   it('does not allow to execute the flash mint callback to users', async () => {
@@ -86,7 +81,10 @@ contract('ExportCdpProxy', async (accounts) => {
       ['address', 'address', 'uint256', 'uint256', 'uint256'],
       [pool1.address, user, cdp.toNumber(), 1, 0]
     )
-    await expectRevert(exportCdpProxy.executeOnFlashMint(1, data, { from: user }), 'ExportCdpProxy: Restricted callback')
+    await expectRevert(
+      exportCdpProxy.executeOnFlashMint(1, data, { from: user }),
+      'ExportCdpProxy: Restricted callback'
+    )
   })
 
   it('does not allow to export to cdp not owned by the user', async () => {
@@ -96,7 +94,7 @@ contract('ExportCdpProxy', async (accounts) => {
 
     await expectRevert(
       exportCdpProxy.exportCdpPosition(pool1.address, 2, bnify(wethTokens1).mul(2), toBorrow, toRay(1), { from: user }),
-      'ExportCdpProxy: User doesn\'t have rights to the target cdp'
+      "ExportCdpProxy: User doesn't have rights to the target cdp"
     )
   })
 
@@ -113,7 +111,9 @@ contract('ExportCdpProxy', async (accounts) => {
     await controller.borrow(WETH, maturity1, user, user, toBorrow, { from: user })
 
     await expectRevert(
-      exportCdpProxy.exportCdpPosition(pool1.address, cdp, bnify(wethTokens1).mul(2), toBorrow, toRay(1), { from: user }),
+      exportCdpProxy.exportCdpPosition(pool1.address, cdp, bnify(wethTokens1).mul(2), toBorrow, toRay(1), {
+        from: user,
+      }),
       'ExportCdpProxy: Not enough collateral in Yield'
     )
   })
@@ -181,6 +181,14 @@ contract('ExportCdpProxy', async (accounts) => {
     )
     const controllerSig = sign(controllerDigest, userPrivateKey)
 
-    await exportCdpProxy.exportCdpPositionWithSignature(pool1.address, cdp, wethTokens1, toBorrow, toRay(1), controllerSig, { from: user })
+    await exportCdpProxy.exportCdpPositionWithSignature(
+      pool1.address,
+      cdp,
+      wethTokens1,
+      toBorrow,
+      toRay(1),
+      controllerSig,
+      { from: user }
+    )
   })
 })

--- a/test/shared/fyDaiForMint.ts
+++ b/test/shared/fyDaiForMint.ts
@@ -7,8 +7,8 @@ export function fyDaiForMint(
   fyDaiRealReserves: any,
   fyDaiVirtualReserves: any,
   dai: any,
-  timeTillMaturity: any): any
-{
+  timeTillMaturity: any
+): any {
   const Z = bignumber(daiReserves)
   const YR = bignumber(fyDaiRealReserves)
   const YV = bignumber(fyDaiVirtualReserves)
@@ -17,27 +17,28 @@ export function fyDaiForMint(
 
   let min = bignumber(0)
   let max = z
-  let y_out = divide(add(min, max), bignumber(2))                       // average
-  
+  let y_out = divide(add(min, max), bignumber(2)) // average
+
   let i = 0
   while (true) {
     const z_in = bignumber(buyFYDai(Z, YV, y_out, t))
-    const Z_1 = add(Z, z_in)                                            // New dai reserves
-    const Y_1 = subtract(YR, y_out)                                      // New fyDai reserves
-  
-    const pz = divide(subtract(z, z_in), add(subtract(z, z_in), y_out))  // dai proportion in my assets
-    const PZ = divide(Z_1, add(Z_1, Y_1))                                // dai proportion in the reserves
+    const Z_1 = add(Z, z_in) // New dai reserves
+    const Y_1 = subtract(YR, y_out) // New fyDai reserves
+
+    const pz = divide(subtract(z, z_in), add(subtract(z, z_in), y_out)) // dai proportion in my assets
+    const PZ = divide(Z_1, add(Z_1, Y_1)) // dai proportion in the reserves
     // console.log(`i = ${i}`)
     // console.log(`pz = ${pz}`)
     // console.log(`PZ = ${PZ}`)
-    
-  
+
     // The dai proportion in my assets needs to be higher than but very close to the dai proportion in the reserves, to make sure all the fyDai is used.
-    if (multiply(PZ, bignumber(1.000001)) <= pz) min = y_out; y_out = divide(add(y_out, max), bignumber(2))                               // bought too little fyDai, buy some more
-    if (pz <= PZ) max = y_out; y_out = divide(add(y_out, min), bignumber(2))  // bought too much fyDai, buy a bit less
+    if (multiply(PZ, bignumber(1.000001)) <= pz) min = y_out
+    y_out = divide(add(y_out, max), bignumber(2)) // bought too little fyDai, buy some more
+    if (pz <= PZ) max = y_out
+    y_out = divide(add(y_out, min), bignumber(2)) // bought too much fyDai, buy a bit less
     // console.log(`y = ${floor(y_out).toFixed()}\n`)
-    
-    if (multiply(PZ, bignumber(1.000001)) > pz && pz > PZ) return floor(y_out).toFixed()            // Just right
+
+    if (multiply(PZ, bignumber(1.000001)) > pz && pz > PZ) return floor(y_out).toFixed() // Just right
 
     if (i++ > 10000) return floor(y_out).toFixed()
   }

--- a/test/shared/fyDaiForMint.ts
+++ b/test/shared/fyDaiForMint.ts
@@ -1,0 +1,37 @@
+import { buyFYDai } from './yieldspace'
+
+const { bignumber, add, subtract, multiply, divide, floor } = require('mathjs')
+
+export function fyDaiForMint(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
+  const Z = bignumber(daiReserves)
+  const Y = bignumber(fyDaiReserves)
+  const z = bignumber(dai)
+  const t = bignumber(timeTillMaturity)
+
+  let min = bignumber(0)
+  let max = z
+  let y_out = divide(add(min, max), bignumber(2))                       // average
+  
+  let i = 0
+  while (true) {
+    const z_in = bignumber(buyFYDai(Z, Y, y_out, t))
+    const Z_1 = add(Z, z_in)                                            // New dai reserves
+    const Y_1 = subtract(Y, y_out)                                      // New fyDai reserves
+  
+    const p = divide(subtract(z, z_in), add(subtract(z, z_in), y_out))  // dai proportion in my assets
+    const P = divide(Z_1, add(Z_1, Y_1))                                // dai proportion in the reserves
+    console.log(`i = ${i}`)
+    console.log(`p = ${p}`)
+    console.log(`P = ${P}`)
+    
+  
+    // The dai proportion in my assets needs to be higher than but very close to the dai proportion in the reserves, to make sure all the fyDai is used.
+    if (multiply(P, bignumber(1.000001)) <= p) min = y_out; y_out = divide(add(y_out, max), bignumber(2))                               // bought too little fyDai, buy some more
+    if (p <= P) max = y_out; y_out = divide(add(y_out, min), bignumber(2))  // bought too much fyDai, buy a bit less
+    console.log(`y = ${floor(y_out).toFixed()}\n`)
+    
+    if (multiply(P, bignumber(1.000001)) > p && p > P) return floor(y_out).toFixed()            // Just right
+
+    if (i++ > 10000) return floor(y_out).toFixed()
+  }
+}

--- a/test/shared/fyDaiForMint.ts
+++ b/test/shared/fyDaiForMint.ts
@@ -27,15 +27,15 @@ export function fyDaiForMint(
   
     const pz = divide(subtract(z, z_in), add(subtract(z, z_in), y_out))  // dai proportion in my assets
     const PZ = divide(Z_1, add(Z_1, Y_1))                                // dai proportion in the reserves
-    console.log(`i = ${i}`)
-    console.log(`pz = ${pz}`)
-    console.log(`PZ = ${PZ}`)
+    // console.log(`i = ${i}`)
+    // console.log(`pz = ${pz}`)
+    // console.log(`PZ = ${PZ}`)
     
   
     // The dai proportion in my assets needs to be higher than but very close to the dai proportion in the reserves, to make sure all the fyDai is used.
     if (multiply(PZ, bignumber(1.000001)) <= pz) min = y_out; y_out = divide(add(y_out, max), bignumber(2))                               // bought too little fyDai, buy some more
     if (pz <= PZ) max = y_out; y_out = divide(add(y_out, min), bignumber(2))  // bought too much fyDai, buy a bit less
-    console.log(`y = ${floor(y_out).toFixed()}\n`)
+    // console.log(`y = ${floor(y_out).toFixed()}\n`)
     
     if (multiply(PZ, bignumber(1.000001)) > pz && pz > PZ) return floor(y_out).toFixed()            // Just right
 

--- a/test/shared/fyDaiForMint.ts
+++ b/test/shared/fyDaiForMint.ts
@@ -2,9 +2,16 @@ import { buyFYDai } from './yieldspace'
 
 const { bignumber, add, subtract, multiply, divide, floor } = require('mathjs')
 
-export function fyDaiForMint(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
+export function fyDaiForMint(
+  daiReserves: any,
+  fyDaiRealReserves: any,
+  fyDaiVirtualReserves: any,
+  dai: any,
+  timeTillMaturity: any): any
+{
   const Z = bignumber(daiReserves)
-  const Y = bignumber(fyDaiReserves)
+  const YR = bignumber(fyDaiRealReserves)
+  const YV = bignumber(fyDaiVirtualReserves)
   const z = bignumber(dai)
   const t = bignumber(timeTillMaturity)
 
@@ -14,23 +21,23 @@ export function fyDaiForMint(daiReserves: any, fyDaiReserves: any, dai: any, tim
   
   let i = 0
   while (true) {
-    const z_in = bignumber(buyFYDai(Z, Y, y_out, t))
+    const z_in = bignumber(buyFYDai(Z, YV, y_out, t))
     const Z_1 = add(Z, z_in)                                            // New dai reserves
-    const Y_1 = subtract(Y, y_out)                                      // New fyDai reserves
+    const Y_1 = subtract(YR, y_out)                                      // New fyDai reserves
   
-    const p = divide(subtract(z, z_in), add(subtract(z, z_in), y_out))  // dai proportion in my assets
-    const P = divide(Z_1, add(Z_1, Y_1))                                // dai proportion in the reserves
+    const pz = divide(subtract(z, z_in), add(subtract(z, z_in), y_out))  // dai proportion in my assets
+    const PZ = divide(Z_1, add(Z_1, Y_1))                                // dai proportion in the reserves
     console.log(`i = ${i}`)
-    console.log(`p = ${p}`)
-    console.log(`P = ${P}`)
+    console.log(`pz = ${pz}`)
+    console.log(`PZ = ${PZ}`)
     
   
     // The dai proportion in my assets needs to be higher than but very close to the dai proportion in the reserves, to make sure all the fyDai is used.
-    if (multiply(P, bignumber(1.000001)) <= p) min = y_out; y_out = divide(add(y_out, max), bignumber(2))                               // bought too little fyDai, buy some more
-    if (p <= P) max = y_out; y_out = divide(add(y_out, min), bignumber(2))  // bought too much fyDai, buy a bit less
+    if (multiply(PZ, bignumber(1.000001)) <= pz) min = y_out; y_out = divide(add(y_out, max), bignumber(2))                               // bought too little fyDai, buy some more
+    if (pz <= PZ) max = y_out; y_out = divide(add(y_out, min), bignumber(2))  // bought too much fyDai, buy a bit less
     console.log(`y = ${floor(y_out).toFixed()}\n`)
     
-    if (multiply(P, bignumber(1.000001)) > p && p > P) return floor(y_out).toFixed()            // Just right
+    if (multiply(PZ, bignumber(1.000001)) > pz && pz > PZ) return floor(y_out).toFixed()            // Just right
 
     if (i++ > 10000) return floor(y_out).toFixed()
   }

--- a/test/shared/yieldspace.ts
+++ b/test/shared/yieldspace.ts
@@ -1,0 +1,113 @@
+const { bignumber, add, subtract, multiply, divide, pow } = require('mathjs')
+
+// https://www.desmos.com/calculator/mllhtohxfx
+export function mint(daiReserves: any, fyDaiReserves: any, supply: any, dai: any): [any, any] {
+  const Z = bignumber(daiReserves)
+  const Y = bignumber(fyDaiReserves)
+  const S = bignumber(supply)
+  const z = bignumber(dai)
+  const m = divide(multiply(S, z), Z)
+  const y = divide(multiply(Y, m), S)
+
+  return [m, y]
+}
+
+// https://www.desmos.com/calculator/ubsalzunpo
+export function burn(daiReserves: any, fyDaiReserves: any, supply: any, lpTokens: any): [any, any] {
+  const Z = bignumber(daiReserves)
+  const Y = bignumber(fyDaiReserves)
+  const S = bignumber(supply)
+  const x = bignumber(lpTokens)
+  const z = divide(multiply(x, Z), S)
+  const y = divide(multiply(x, Y), S)
+
+  return [z, y]
+}
+
+// https://www.desmos.com/calculator/5nf2xuy6yb
+export function sellVYDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
+  const fee = bignumber(1000000000000)
+  const Z = bignumber(daiReserves)
+  const Y = bignumber(fyDaiReserves)
+  const T = bignumber(timeTillMaturity)
+  const x = bignumber(dai)
+  const k = bignumber(1 / (4 * 365 * 24 * 60 * 60)) // 1 / seconds in four years
+  const g = bignumber(950 / 1000)
+  const t = multiply(k, T)
+  const a = subtract(1, multiply(g, t))
+  const invA = divide(1, a)
+  const Za = pow(Z, a)
+  const Ya = pow(Y, a)
+  const Zxa = pow(add(Z, x), a)
+  const sum = subtract(add(Za, Ya), Zxa)
+  const y = subtract(Y, pow(sum, invA))
+  const yFee = subtract(y, fee)
+
+  return yFee
+}
+
+// https://www.desmos.com/calculator/6jlrre7ybt
+export function sellFYDai(daiReserves: any, fyDaiReserves: any, fyDai: any, timeTillMaturity: any): any {
+  const fee = bignumber(1000000000000)
+  const Z = bignumber(daiReserves)
+  const Y = bignumber(fyDaiReserves)
+  const T = bignumber(timeTillMaturity)
+  const x = bignumber(fyDai)
+  const k = bignumber(1 / (4 * 365 * 24 * 60 * 60)) // 1 / seconds in four years
+  const g = bignumber(1000 / 950)
+  const t = multiply(k, T)
+  const a = subtract(1, multiply(g, t))
+  const invA = divide(1, a)
+  const Za = pow(Z, a)
+  const Ya = pow(Y, a)
+  const Yxa = pow(add(Y, x), a)
+  const sum = add(Za, subtract(Ya, Yxa))
+  const y = subtract(Z, pow(sum, invA))
+  const yFee = subtract(y, fee)
+
+  return yFee
+}
+
+// https://www.desmos.com/calculator/0rgnmtckvy
+export function buyVYDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
+  const fee = bignumber(1000000000000)
+  const Z = bignumber(daiReserves)
+  const Y = bignumber(fyDaiReserves)
+  const T = bignumber(timeTillMaturity)
+  const x = bignumber(dai)
+  const k = bignumber(1 / (4 * 365 * 24 * 60 * 60)) // 1 / seconds in four years
+  const g = bignumber(1000 / 950)
+  const t = multiply(k, T)
+  const a = subtract(1, multiply(g, t))
+  const invA = divide(1, a)
+  const Za = pow(Z, a)
+  const Ya = pow(Y, a)
+  const Zxa = pow(subtract(Z, x), a)
+  const sum = subtract(add(Za, Ya), Zxa)
+  const y = subtract(pow(sum, invA), Y)
+  const yFee = add(y, fee)
+
+  return yFee
+}
+
+// https://www.desmos.com/calculator/ws5oqj8x5i
+export function buyFYDai(daiReserves: any, fyDaiReserves: any, fyDai: any, timeTillMaturity: any): any {
+  const fee = bignumber(1000000000000)
+  const Z = bignumber(daiReserves)
+  const Y = bignumber(fyDaiReserves)
+  const T = bignumber(timeTillMaturity)
+  const x = bignumber(fyDai)
+  const k = bignumber(1 / (4 * 365 * 24 * 60 * 60)) // 1 / seconds in four years
+  const g = bignumber(950 / 1000)
+  const t = multiply(k, T)
+  const a = subtract(1, multiply(g, t))
+  const invA = divide(1, a)
+  const Za = pow(Z, a)
+  const Ya = pow(Y, a)
+  const Yxa = pow(subtract(Y, x), a)
+  const sum = add(Za, subtract(Ya, Yxa))
+  const y = subtract(pow(sum, invA), Z)
+  const yFee = add(y, fee)
+
+  return yFee
+}

--- a/test/shared/yieldspace.ts
+++ b/test/shared/yieldspace.ts
@@ -25,7 +25,7 @@ export function burn(daiReserves: any, fyDaiReserves: any, supply: any, lpTokens
 }
 
 // https://www.desmos.com/calculator/5nf2xuy6yb
-export function sellVYDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
+export function sellDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
   const fee = bignumber(1000000000000)
   const Z = bignumber(daiReserves)
   const Y = bignumber(fyDaiReserves)
@@ -42,6 +42,8 @@ export function sellVYDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTi
   const sum = subtract(add(Za, Ya), Zxa)
   const y = subtract(Y, pow(sum, invA))
   const yFee = subtract(y, fee)
+
+  if (divide(y, x) < bignumber(1)) throw new RangeError()
 
   return yFee
 }
@@ -65,11 +67,13 @@ export function sellFYDai(daiReserves: any, fyDaiReserves: any, fyDai: any, time
   const y = subtract(Z, pow(sum, invA))
   const yFee = subtract(y, fee)
 
+  if (divide(y, x) > bignumber(1)) throw new RangeError()
+
   return yFee
 }
 
 // https://www.desmos.com/calculator/0rgnmtckvy
-export function buyVYDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
+export function buyDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTillMaturity: any): any {
   const fee = bignumber(1000000000000)
   const Z = bignumber(daiReserves)
   const Y = bignumber(fyDaiReserves)
@@ -85,6 +89,9 @@ export function buyVYDai(daiReserves: any, fyDaiReserves: any, dai: any, timeTil
   const Zxa = pow(subtract(Z, x), a)
   const sum = subtract(add(Za, Ya), Zxa)
   const y = subtract(pow(sum, invA), Y)
+
+  if (divide(y, x) < bignumber(1)) throw new RangeError()
+
   const yFee = add(y, fee)
 
   return yFee
@@ -108,6 +115,8 @@ export function buyFYDai(daiReserves: any, fyDaiReserves: any, fyDai: any, timeT
   const sum = add(Za, subtract(Ya, Yxa))
   const y = subtract(pow(sum, invA), Z)
   const yFee = add(y, fee)
+
+  if (divide(y, x) > bignumber(1)) throw new RangeError()
 
   return yFee
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1748,6 +1748,11 @@ commander@~2.8.1:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+complex.js@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.0.11.tgz#09a873fbf15ffd8c18c9c2201ccef425c32b8bf1"
+  integrity sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1971,6 +1976,11 @@ decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decimal.js@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -2361,6 +2371,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
+escape-latex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/escape-latex/-/escape-latex-1.2.0.tgz#07c03818cf7dac250cce517f4fda1b001ef2bca1"
+  integrity sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -3367,6 +3382,11 @@ fp-ts@^1.0.0:
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
   integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
 
+fraction.js@^4.0.12:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.0.13.tgz#3c1c315fa16b35c85fffa95725a36fa729c69dfe"
+  integrity sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -4204,6 +4224,11 @@ iterate-value@^1.0.0:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
+javascript-natural-sort@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
+
 js-sha3@0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
@@ -4613,6 +4638,20 @@ markdown-table@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
+
+mathjs@^7.3.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-7.6.0.tgz#f0b7579e0756b13422995d0c4f29bd17d65d4dcc"
+  integrity sha512-abywR28hUpKF4at5jE8Ys+Kigk40eKMT5mcBLD0/dtsqjfOLbtzd3WjlRqIopNo7oQ6FME51qph6lb8h/bhpUg==
+  dependencies:
+    complex.js "^2.0.11"
+    decimal.js "^10.2.1"
+    escape-latex "^1.2.0"
+    fraction.js "^4.0.12"
+    javascript-natural-sort "^0.7.1"
+    seed-random "^2.2.0"
+    tiny-emitter "^2.1.0"
+    typed-function "^2.0.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -5969,6 +6008,11 @@ secp256k1@^4.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
+seed-random@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
+  integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=
+
 seek-bzip@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
@@ -6539,6 +6583,11 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
+tiny-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -6704,6 +6753,11 @@ type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
   integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
+
+typed-function@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-2.0.0.tgz#15ab3825845138a8b1113bd89e60cd6a435739e8"
+  integrity sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
Drafted `buyAddLiquidity`, which buys fyDai in a pool and then uses the proceedings plus Dai from the user to add liquidity.

Deployed in Kovan at: `0x4A38D30F0d451213C51a332773858712cA1dD6E6`