### PR TITLE
fix: only known pools

### DIFF
--- a/contracts/ImportProxy.sol
+++ b/contracts/ImportProxy.sol
@@ -88,6 +88,7 @@ contract ImportProxy is ImportProxyBase, DecimalMath, IFlashMinter {
     /// @param debtAmount Normalized dai debt to move from MakerDAO to Yield. ndai * rate = dai
     /// @param maxDaiPrice Maximum fyDai price to pay for Dai
     function importFromProxy(IPool pool, address user, uint256 wethAmount, uint256 debtAmount, uint256 maxDaiPrice) public {
+        require(knownPools[address(pool)], "ImportProxy: Only known pools");
         require(user == msg.sender || proxyRegistry.proxies(user) == msg.sender, "Restricted to user or its dsproxy");
         // The user specifies the fyDai he wants to mint to cover his maker debt, the weth to be passed on as collateral, and the dai debt to move
         (uint256 ink, uint256 art) = vat.urns(WETH, address(this));
@@ -121,8 +122,8 @@ contract ImportProxy is ImportProxyBase, DecimalMath, IFlashMinter {
     function executeOnFlashMint(uint256, bytes calldata data) external override {
         (IPool pool, address user, uint256 wethAmount, uint256 debtAmount) = 
             abi.decode(data, (IPool, address, uint256, uint256));
+        require(knownPools[address(pool)], "ImportProxy: Only known pools");
         require(msg.sender == address(IPool(pool).fyDai()), "ImportProxy: Callback restricted to the fyDai matching the pool");
-        // require(vat.can(address(this), user) == 1, "ImportProxy: Unauthorized by user");
 
         _importFromProxy(pool, user, wethAmount, debtAmount);
     }

--- a/contracts/ImportProxyBase.sol
+++ b/contracts/ImportProxyBase.sol
@@ -29,6 +29,8 @@ contract ImportProxyBase {
 
     bytes32 public constant WETH = "ETH-A";
 
+    mapping(address => bool) knownPools;
+
     constructor(IController controller_, IPool[] memory pools_, IProxyRegistry proxyRegistry_) public {
         ITreasury _treasury = controller_.treasury();
 
@@ -41,9 +43,10 @@ contract ImportProxyBase {
         controller = controller_;
         proxyRegistry = proxyRegistry_;
 
-        // Allow pool to take fyDai for trading
+        // Register pool and allow it to take fyDai for trading
         for (uint i = 0 ; i < pools_.length; i++) {
             pools_[i].fyDai().approve(address(pools_[i]), type(uint256).max);
+            knownPools[address(pools_[i])] = true;
         }
 
         // Allow treasury to take weth for posting

--- a/contracts/ImportProxyBase.sol
+++ b/contracts/ImportProxyBase.sol
@@ -29,7 +29,7 @@ contract ImportProxyBase {
 
     bytes32 public constant WETH = "ETH-A";
 
-    mapping(address => bool) knownPools;
+    mapping(address => bool) public knownPools;
 
     constructor(IController controller_, IPool[] memory pools_, IProxyRegistry proxyRegistry_) public {
         ITreasury _treasury = controller_.treasury();

--- a/test/541_importProxy.ts
+++ b/test/541_importProxy.ts
@@ -101,6 +101,17 @@ contract('ImportProxy', async (accounts) => {
     assert.equal(await vat.can(importProxy.address, dsProxy.address), 0)
   })
 
+  it('does not allow to execute the flash mint with unknown pools', async () => {
+    const data = web3.eth.abi.encodeParameters(
+      ['address', 'address', 'uint256', 'uint256'],
+      [user, user, 1, 0]
+    )
+    await expectRevert(
+      importProxy.executeOnFlashMint(1, data, { from: user }),
+      'ImportProxy: Only known pools'
+    )
+  })
+
   it('does not allow to execute the flash mint callback to users', async () => {
     const data = web3.eth.abi.encodeParameters(
       ['address', 'address', 'uint256', 'uint256'],
@@ -109,6 +120,15 @@ contract('ImportProxy', async (accounts) => {
     await expectRevert(
       importProxy.executeOnFlashMint(1, data, { from: user }),
       'Callback restricted to the fyDai matching the pool'
+    )
+  })
+
+  it('does not allow to pass unknown pools to the static import function', async () => {
+    await expectRevert(
+      importProxy.importFromProxy(user, user, 0, 0, 0, {
+        from: user,
+      }),
+      'ImportProxy: Only known pools'
     )
   })
 

--- a/test/542_importCdpProxy.ts
+++ b/test/542_importCdpProxy.ts
@@ -102,6 +102,17 @@ contract('ImportCdpProxy', async (accounts) => {
     await vat.move(user, urn, rad, { from: user }) // cdpMgr.enter leaves fractions of a wei behind :(
   })
 
+  it('does not allow to execute the flash mint callback with unknown pools', async () => {
+    const data = web3.eth.abi.encodeParameters(
+      ['address', 'address', 'uint256', 'uint256', 'uint256'],
+      [user, user, 1, 1, 0]
+    )
+    await expectRevert(
+      importCdpProxy.executeOnFlashMint(1, data, { from: user }),
+      'ImportCdpProxy: Only known pools'
+    )
+  })
+
   it('does not allow to execute the flash mint callback to users', async () => {
     const data = web3.eth.abi.encodeParameters(
       ['address', 'address', 'uint256', 'uint256', 'uint256'],
@@ -112,6 +123,16 @@ contract('ImportCdpProxy', async (accounts) => {
       'ImportCdpProxy: Callback restricted to the fyDai matching the pool'
     )
   })
+
+  it('does not allow to call the static import with unknown pools', async () => {
+    await expectRevert(
+      importCdpProxy.importCdpFromProxy(user, user, cdp, 0, 0, 0, {
+        from: user,
+      }),
+      'ImportCdpProxy: Only known pools'
+    )
+  })
+
 
   it('does not allow to move more debt than existing in maker', async () => {
     // Give CDP to static ImportCdpProxy

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -88,7 +88,7 @@ module.exports = {
       network_id: 1,         // Mainnet's id
       confirmations: 0,       // # of confs to wait between deployments. (default: 0)
       timeoutBlocks: 1000,     // # of blocks before a deployment times out  (minimum/default: 50)
-      gasPrice: 20000000000,  // 20 gwei
+      gasPrice: 100000000000,  // 100 gwei
       skipDryRun: false       // Skip dry run before migrations? (default: false for public nets )
     },
 
@@ -97,7 +97,7 @@ module.exports = {
       network_id: 42,         // Kovan's id
       confirmations: 0,       // # of confs to wait between deployments. (default: 0)
       timeoutBlocks: 200,     // # of blocks before a deployment times out  (minimum/default: 50)
-      gasPrice: 10000000000,  // 10 gwei
+      gasPrice: 100000000000,  // 100 gwei
       skipDryRun: false       // Skip dry run before migrations? (default: false for public nets )
     },
 


### PR DESCRIPTION
Fixing static functions and flash loan callbacks to be called only with known pools.

Kovan:
```
ImportProxy: '0xe713DA979FaE7470b5216Dca0b287a02BBfe8184
ImportCdpProxy: '0xA5286e1Cb19Bd62a3369f641C8c3F1e2dEa1089d
```